### PR TITLE
Bluexp 996 rns auto

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -1,13 +1,12 @@
 settings:
   name: E-Series
-  platform: cloud
+  release_notes_autogen:
+      release_notes_repo: console-relnotes
   internal:
     pdf_enabled: true
   prod:
     pdf_enabled: true
     harmony_enabled: true
-    release_notes_autogen:
-      release_notes_repo: console-relnotes
 sidebar:
   entries:
     - title: E-Series docs


### PR DESCRIPTION
This pull request updates the `project.yml` configuration to move the `release_notes_autogen` setting out of the `prod` environment and into the top-level settings. This change ensures that the release notes automation applies globally, not just in production.

Configuration changes:

* Moved the `release_notes_autogen` block (with `release_notes_repo: console-relnotes`) from under the `prod` environment to the top-level settings in `project.yml`, making the release notes automation a global setting.